### PR TITLE
MapCache-803: Fix the longitude values when wrapping the earth.

### DIFF
--- a/src/lib/leaflet/map/controls/LeafletCoordinates.js
+++ b/src/lib/leaflet/map/controls/LeafletCoordinates.js
@@ -33,7 +33,8 @@ export default class LeafletCoordinates extends L.Control {
     let text = ''
     if (coordinate != null && coordinateType != null) {
       if (coordinateType === 'LatLng') {
-        text = 'Lat, Lng: ' + coordinate.lat.toFixed(6) + ', ' + coordinate.lng.toFixed(6)
+        const lng = window.mapcache.normalizeLongitude(coordinate.lng) // Limit longitude to range [-180, 180]
+        text = 'Lat, Lng: ' + coordinate.lat.toFixed(6) + ', ' + lng.toFixed(6)
       } else if (coordinateType === 'MGRS') {
         const mgrs = MGRS.from(new LatLng(coordinate.lat, coordinate.lng))
         text = 'MGRS: ' + mgrs.toString()


### PR DESCRIPTION
Fixes the wrapping in both directions using an existing `normalizeLongitude()` function on the tiny Lat/Lng widget.

<img width="271" alt="Clamping values to -180 to 180" src="https://github.com/user-attachments/assets/f2f4a07f-050e-4bb9-b496-1b782d135f69" />


* [MapCache-803](https://gitlab.dso.xc.nga.mil/MapCache/mapcache/mapcache/-/issues/806)

https://github.com/user-attachments/assets/fc7f228f-4392-4e56-885f-09d5e70d9c91

